### PR TITLE
Fix grammar error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ PHP Assignment Display
 Overview
 -------------
 
-This is an very simple app to retrieve C++ source file from my school's working directory with syntax highlighting and generate an HTML page to display the code using PHP.
+This is a simple app to retrieve C++ source file from my school's working directory with syntax highlighting and generate an HTML page to display the code using PHP.
 
 Usage
 ---------
 
-Arguments that the app takes is `$type` and `$id`.
+Parameters are `$type` and `$id`.
 
-For example, if I want to retrieve an assignment called asn1.cpp, I have to specify this in URL: 
+For example, to retrieve an assignment called asn1.cpp, specify this in URL: 
        `http://www.example.com/asn.php?type=asn&id=asn1`
 where `$type` is usually `asn` for assignment and `ex` for exercise. `$id` is usually the filename without extension.
 


### PR DESCRIPTION
- "very" simple is unnecessary.
- Change "For example, if I want to retrieve an assignment called asn1.cpp, I have to specify this in URL:" to "For example, to retrieve an assignment called asn1.cpp, specify this in URL:". Make it more intuitive to read. 